### PR TITLE
patch alignDraw to allow floatX=float32 and added savedir

### DIFF
--- a/mnist-captions/models/mnist-captions.json
+++ b/mnist-captions/models/mnist-captions.json
@@ -16,6 +16,7 @@
 
     "validateAfter": 3,
     "save": false,
+    "savedir": "/nobackup_b/emansim/variational-weights",
     "lr": 0.001,
     "epochs": 1000,
     "batch_size": 100,
@@ -30,7 +31,7 @@
             "key": "train_labels",
             "file": "/ais/gobi3/u/nitish/mnist/mnist.h5"
         },
-        "validation": {
+        "validation_data": {
             "key": "validation",
             "file": "/ais/gobi3/u/nitish/mnist/mnist.h5"
         },


### PR DESCRIPTION
Updated alignDraw.py to allow theano.config.floatX=float32
similar to the procedure done to draw.py in commit 0b55a249

Also tweaked the loading of the settings json file, including
adding an explicit savedir for saving weights and aligned some
other json key names so that they would match the code.
